### PR TITLE
Fix issue where the extension hide the top section of the forum

### DIFF
--- a/__tests__/content.test.js
+++ b/__tests__/content.test.js
@@ -33,7 +33,7 @@ describe('Content Script', () => {
       contentModule.hideSoldItems();
 
       expect(document.querySelectorAll).toHaveBeenCalledWith(
-        'div.structItem--thread:has(.structItem-status--locked)'
+        'div.structItemContainer-group.js-threadList div.structItem--thread:has(.structItem-status--locked)'
       );
       expect(mockElement.style.display).toBe('none');
     });
@@ -45,7 +45,7 @@ describe('Content Script', () => {
       contentModule.hideSoldItems();
 
       expect(document.querySelectorAll).toHaveBeenCalledWith(
-        'div.structItem--thread:has(.structItem-status--locked)'
+        'div.structItemContainer-group.js-threadList div.structItem--thread:has(.structItem-status--locked)'
       );
     });
 
@@ -71,7 +71,7 @@ describe('Content Script', () => {
       contentModule.showAllItems();
 
       expect(document.querySelectorAll).toHaveBeenCalledWith(
-        'div.structItem--thread:has(.structItem-status--locked)'
+        'div.structItemContainer-group.js-threadList div.structItem--thread:has(.structItem-status--locked)'
       );
       expect(mockElement.style.display).toBe('');
     });
@@ -100,7 +100,7 @@ describe('Content Script', () => {
       messageCallback({ action: 'enableFilter' }, {}, sendResponse);
 
       expect(document.querySelectorAll).toHaveBeenCalledWith(
-        'div.structItem--thread:has(.structItem-status--locked)'
+        'div.structItemContainer-group.js-threadList div.structItem--thread:has(.structItem-status--locked)'
       );
       expect(sendResponse).toHaveBeenCalledWith({ success: true });
     });
@@ -113,7 +113,7 @@ describe('Content Script', () => {
       messageCallback({ action: 'disableFilter' }, {}, sendResponse);
 
       expect(document.querySelectorAll).toHaveBeenCalledWith(
-        'div.structItem--thread:has(.structItem-status--locked)'
+        'div.structItemContainer-group.js-threadList div.structItem--thread:has(.structItem-status--locked)'
       );
       expect(sendResponse).toHaveBeenCalledWith({ success: true });
     });
@@ -133,7 +133,7 @@ describe('Content Script', () => {
       require('../content');
 
       expect(document.querySelectorAll).toHaveBeenCalledWith(
-        'div.structItem--thread:has(.structItem-status--locked)'
+        'div.structItemContainer-group.js-threadList div.structItem--thread:has(.structItem-status--locked)'
       );
     });
 
@@ -172,7 +172,7 @@ describe('Content Script', () => {
       handler();
 
       expect(document.querySelectorAll).toHaveBeenCalledWith(
-        'div.structItem--thread:has(.structItem-status--locked)'
+        'div.structItemContainer-group.js-threadList div.structItem--thread:has(.structItem-status--locked)'
       );
     });
   });

--- a/content.js
+++ b/content.js
@@ -1,7 +1,7 @@
 // Function to hide sold items
 function hideSoldItems() {
   try {
-    const soldItems = document.querySelectorAll("div.structItem--thread:has(.structItem-status--locked)");
+    const soldItems = document.querySelectorAll("div.structItemContainer-group.js-threadList div.structItem--thread:has(.structItem-status--locked)");
     soldItems.forEach(el => {
       if (el && el.style) {
         el.style.display = 'none';
@@ -15,7 +15,7 @@ function hideSoldItems() {
 // Function to show all items
 function showAllItems() {
   try {
-    const soldItems = document.querySelectorAll("div.structItem--thread:has(.structItem-status--locked)");
+    const soldItems = document.querySelectorAll("div.structItemContainer-group.js-threadList div.structItem--thread:has(.structItem-status--locked)");
     soldItems.forEach(el => {
       if (el && el.style) {
         el.style.display = '';

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Laneros Item Filter",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Hide sold items on laneros.com marketplace",
   "permissions": ["activeTab", "storage"],
   "action": {


### PR DESCRIPTION
This PR contains the changes to make the extension hide only the items being sold/bough since the previous version hide the sticky section at the top of the initial page.